### PR TITLE
fix_for_list_equality: Added equality check for iterable, list, set and map

### DIFF
--- a/lib/src/matcher.dart
+++ b/lib/src/matcher.dart
@@ -5,6 +5,7 @@ library stream_test_scheduler.matcher;
 
 import 'package:matcher/matcher.dart';
 import 'package:stream_test_scheduler/src/record.dart';
+import 'package:collection/equality.dart';
 
 equalsRecords(List<Record> records, {int maxDeviation: 0}) {
   return pairwiseCompare(records, (Record r1, Record r2) {
@@ -13,6 +14,20 @@ equalsRecords(List<Record> records, {int maxDeviation: 0}) {
       return false;
     }
     if (r1 is OnNextRecord && r2 is OnNextRecord) {
+
+      if(r1.value is Iterable && r2.value is Iterable) {
+        return new IterableEquality().equals(r1.value, r2.value);
+      }
+      if(r1.value is List && r2.value is List) {
+        return new ListEquality().equals(r1.value, r2.value);
+      }
+      if(r1.value is Set && r2.value is Set) {
+        return new SetEquality().equals(r1.value, r2.value);
+      }
+      if(r1.value is Map && r2.value is Map) {
+        return new MapEquality().equals(r1.value, r2.value);
+      }
+
       return r1.value == r2.value;
     }
     if (r1 is OnErrorRecord && r2 is OnErrorRecord) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 
 dependencies:
   matcher: ^0.12.0
+  collection : 1.1.3
 
 dev_dependencies:
   stream_ext: ^0.4.0


### PR DESCRIPTION
<h3>CODE REVIEW AND MERGE</h3>

<p>Please consider the following change that corrects an issue where two lists that contain the same items were not considered equal.  The change also covers maps, sets and iterables.
</p>

<p><strong>Required:</strong><br/>
@maiermic
</p>
